### PR TITLE
Enable gccgo based builds on Intel

### DIFF
--- a/sha256/sha256block.go
+++ b/sha256/sha256block.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !386,!amd64
+// +build !gc
 
 // SHA256 block step.
 // In its own file so that a faster assembly or C version

--- a/sha256/sha256block_386.s
+++ b/sha256/sha256block_386.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build gc
+
 // SHA256 block routine. See sha256block.go for Go equivalent.
 //
 // The algorithm is detailed in FIPS 180-4:

--- a/sha256/sha256block_amd64.s
+++ b/sha256/sha256block_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build gc
+
 #include "textflag.h"
 
 // SHA256 block routine. See sha256block.go for Go equivalent.

--- a/sha512/sha512block.go
+++ b/sha512/sha512block.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64
+// +build !gc
 
 // SHA512 block step.
 // In its own file so that a faster assembly or C version

--- a/sha512/sha512block_amd64.s
+++ b/sha512/sha512block_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build gc
+
 #include "textflag.h"
 
 // SHA512 block routine. See sha512block.go for Go equivalent.


### PR DESCRIPTION
The existing code doesn't compile with gccgo toolchain on Intel since the assembly code for sha256block and sha512block is specific to golang toolchain. The patch adds build constraints so that the code can be built with gccgo on multiple platforms including Intel and PowerPC. 

Tested on the following environment
$go version
go version go1.4.2 gccgo (Ubuntu 5.1~rc1-0ubuntu1) 5.0.1 20150414 (prerelease) [gcc-5-branch revision 222102] linux/amd64

$ go version
go version go1.4.2 gccgo (GCC) 5.1.1 20150610 linux/ppc64le

Signed-off-by: Pradipta Kr. Banerjee <bpradip@in.ibm.com>